### PR TITLE
Config/bump dependencies

### DIFF
--- a/.github/workflows/detekt-ci.yml
+++ b/.github/workflows/detekt-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Run detekt

--- a/.github/workflows/gradlew-build-workflow.yml
+++ b/.github/workflows/gradlew-build-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run MVI Sample Gradle Build

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.20" />
+    <option name="version" value="1.8.0-RC2" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
-import org.gradle.accessors.dm.LibrariesForLibs
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
@@ -12,6 +11,7 @@ plugins {
     alias(libs.plugins.detekt) apply (false)
     alias(libs.plugins.ksp) apply (false)
     alias(libs.plugins.hilt) apply (false)
+    alias(libs.plugins.gradle.versions)
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 androidX-ktx-core = "1.9.0"
-androidX-lifecycle-runtime = "2.5.1"
-androidX-lifecycle-viewmodel = "2.5.1"
+androidX-lifecycle-runtime = "2.6.0-alpha03"
+androidX-lifecycle-viewmodel = "2.6.0-alpha03"
 
 androidX-compose-activity = "1.6.1"
-androidX-compose-bom = "2022.10.00"
-androidX-compose-compiler = "1.3.2"
+androidX-compose-bom = "2022.12.00"
+androidX-compose-compiler = "1.4.0-alpha02"
 
 androidX-test-junit = "1.1.4"
 androidX-test-espresso = "3.5.0"
@@ -16,13 +16,14 @@ truth = "1.1.3"
 
 detekt = "1.22.0"
 agp = "8.0.0-alpha10"
-kotlin = "1.7.20"
-ksp = "1.7.20-1.0.8"
+kotlin = "1.7.21"
+ksp = "1.7.21-1.0.8"
+gradle-versions = "0.44.0"
 
 coroutines = "1.6.4"
 
 coil = "2.2.2"
-room = "2.4.3"
+room = "2.5.0-rc01"
 
 hilt = "2.44.2"
 
@@ -71,6 +72,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+gradle-versions = { id = "com.github.ben-manes.versions", version.ref = "gradle-versions" }
 
 [bundles]
 compose-debug = ["androidX-compose-debug-tooling", "androidX-compose-debug-manifest"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ turbine = "0.12.1"
 truth = "1.1.3"
 
 detekt = "1.22.0"
-agp = "8.0.0-alpha09"
+agp = "8.0.0-alpha10"
 kotlin = "1.7.20"
 ksp = "1.7.20-1.0.8"
 


### PR DESCRIPTION
- Update project dependencies
- Bump Kotlin Version to 1.7.21
- Adds [Gradle plugin to check for dependencies](https://github.com/littlerobots/version-catalog-update-plugin) 
- Bumps CI runner's java version to 17