### PR TITLE
Config/dependncy bump

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidX-lifecycle-viewmodel = "2.6.0-alpha03"
 androidX-compose-activity = "1.7.0-alpha02"
 androidX-compose-core = "1.4.0-alpha03"
 androidX-compose-coreStable = "1.3.2"
-androidX-compose-material3 = "1.1.0-alpha02"
+androidX-compose-material3 = "1.1.0-alpha03"
 androidX-compose-material = "1.3.1"
 androidX-compose-compiler = "1.4.0-alpha02"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,15 @@ androidX-ktx-core = "1.9.0"
 androidX-lifecycle-runtime = "2.6.0-alpha03"
 androidX-lifecycle-viewmodel = "2.6.0-alpha03"
 
-androidX-compose-activity = "1.6.1"
-androidX-compose-core = "1.4.0-alpha02"
+androidX-compose-activity = "1.7.0-alpha02"
+androidX-compose-core = "1.4.0-alpha03"
 androidX-compose-coreStable = "1.3.2"
 androidX-compose-material3 = "1.1.0-alpha02"
+androidX-compose-material = "1.3.1"
 androidX-compose-compiler = "1.4.0-alpha02"
 
-androidX-test-junit = "1.1.4"
-androidX-test-espresso = "3.5.0"
+androidX-test-junit = "1.1.5"
+androidX-test-espresso = "3.5.1"
 
 junit = "4.13.2"
 turbine = "0.12.1"
@@ -44,6 +45,7 @@ androidX-compose-icons = { module = "androidx.compose.material:material-icons-ex
 androidX-compose-graphics = { module = "androidx.compose.ui:ui-graphics", version.ref = "androidX-compose-core" }
 androidX-compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidX-compose-core" }
 androidX-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidX-compose-material3" }
+androidX-compose-material = { module = "androidx.compose.material:material", version.ref = "androidX-compose-material" }
 androidX-compose-test-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidX-compose-core" }
 androidX-compose-debug-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidX-compose-core" }
 androidX-compose-debug-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidX-compose-core" }


### PR DESCRIPTION
- Activity Compose: 1.6.1 -> 1.7.0-alpha02
- Material 3: 1.1.0-alpha02 -> 1.1.0-alpha03
- Compose: 1.4.0-alpha02 -> 1.4.0-alpha03
- Espresso: 3.5.0 -> 3.5.1
- Junit Ext: 1.1.4 -> 1.1.5
- Material Icons Extended: 1.4.0-alpha02 -> 1.4.0-alpha03

Kotlin (and subsequently KSP) version won't be bumped because the [compose compiler 1.4.0-alpha02](https://developer.android.com/jetpack/androidx/releases/compose-compiler?gclid=CjwKCAiAqt-dBhBcEiwATw-ggNNZfVbrmeo4nohJqyvk8WBXI57iki5yZeuxw9O2VruAXNpkKiDqYBoCOpUQAvD_BwE&gclsrc=aw.ds) which is the latest release of compose's compiler doesn't have official support for Kotlin 1.8